### PR TITLE
Apply README feedback

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,7 +25,7 @@
 = Deploying microservices to IBM Cloud
 
 [.hidden]
-NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].
+NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website^].
  
 Explore how to push Docker images to a custom registry and run them inside of containers on IBM Cloud’s Kubernetes service.
 
@@ -55,7 +55,8 @@ Single node {kube} clusters such as Minikube and Docker Desktop are great for te
 
 You will learn how to deploy two microservices in Open Liberty containers to a {kube}
 cluster on IBM Cloud. You will use `helm` to deploy these microservices using
-Open Liberty Helm charts.
+Open Liberty Helm charts. Helm is a package manager for {kube}. It uses templates to
+generate {kube} yaml files and then deploys and manages them as releases to your cluster.
 
 IBM Cloud offers a hosted Kubernetes service called IBM Cloud Kubernetes Service (IKS). IKS is a service offered as part of IBM's public cloud offerings. It provides a hosted {kube} cluster that you may deploy your microservices to. You will use it in conjunction with IBM Cloud Container Registry.
 
@@ -71,7 +72,7 @@ how communication can be established between pods inside a cluster.
 
 == Prerequisites
 
-To create a {kube} cluster you need appropriate permission. Ensure that you have `Administrator` access to IBM Cloud Kubernetes Service. Navigate to the https://cloud.ibm.com/[IBM Cloud Dashboard]. Then navigate to `Manage > Access (IAM) > Users > [Your Username] > Access Policies`. Ensure that `Administrator` is listed as a policy.
+To create a {kube} cluster you need appropriate permission. Ensure that you have `Administrator` access to IBM Cloud Kubernetes Service. Navigate to the https://cloud.ibm.com/[IBM Cloud Dashboard^]. Then navigate to `Manage > Access (IAM) > Users > [Your Username] > Access Policies` and ensure that `Administrator` is listed as a policy.
 
 // =================================================================================================
 // Getting Started
@@ -87,7 +88,7 @@ include::{common-includes}/gitclone.adoc[]
 === Installing command line tools for IBM Cloud
 
 Use the following command to download and install everything you will need to interact with IBM Cloud.
-Running this script will install https://console.bluemix.net/docs/cli/index.html#overview[several tools]
+Running this script will install https://console.bluemix.net/docs/cli/index.html#overview[several tools^]
 that will be useful for interacting with IBM Cloud. It will install the `ibmcloud`, `kubectl`, `helm`,
 and `curl` tools which are needed to complete this guide.
 
@@ -101,11 +102,11 @@ curl -sL https://ibm.biz/idt-installer | bash
 
 [system]#*{win}*#
 
-Open PowerShell as an administrator and run the following command.
+Open command prompt as an administrator and run the following command.
 
 [role=command]
 ```
-Set-ExecutionPolicy Unrestricted; iex(New-Object Net.WebClient).DownloadString('http://ibm.biz/idt-win-installer')
+powershell -command "Set-ExecutionPolicy Unrestricted; iex(New-Object Net.WebClient).DownloadString('http://ibm.biz/idt-win-installer')"
 ```
 ****
 
@@ -230,7 +231,7 @@ The starting Java project, which you can find in the `start` directory, is a mul
 project. It's made up of the `name` and `ping` microservices. Each microservice resides in its own directory,
 `start/name` and `start/ping`. Each of these directories also contains a Dockerfile, which is necessary
 for building Docker images. If you're unfamiliar with Dockerfiles, check out the
-https://openliberty.io/guides/docker.html[Using Docker containers to develop microservices] guide.
+https://openliberty.io/guides/docker.html[Using Docker containers to develop microservices^] guide.
 It covers Dockerfiles in depth.
 
 If you're familiar with Maven and Docker, you might be tempted to run a Maven build first and then
@@ -380,6 +381,9 @@ helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/rep
 // Deploy to IKS
 Use Helm to deploy the `name` microservice. Remeber to substitute `[your-namespace]` for the namespace you created earlier in the guide.
 
+****
+[system]#*{linux} | {mac}*#
+
 [role=command]
 ```
 helm install --name name-app \
@@ -391,7 +395,25 @@ helm install --name name-app \
     ibm-charts/ibm-open-liberty
 ```
 
+[system]#*{win}*#
+
+[role=command]
+```
+helm install --name name-app ^
+    --set image.repository=registry.ng.bluemix.net/[your-namespace]/name ^
+    --set image.tag=1.0-SNAPSHOT ^
+    --set service.port=9080 ^
+    --set service.targetPort=9080 ^
+    --set ssl.enabled=false ^
+    ibm-charts/ibm-open-liberty
+```
+
+****
+
 Use Helm to deploy the `ping` microservice. Remeber to substitute `[your-namespace]` for the namespace you created earlier in the guide.
+
+****
+[system]#*{linux} | {mac}*#
 
 [role=command]
 ```
@@ -403,6 +425,22 @@ helm install --name ping-app \
     --set ssl.enabled=false \
     ibm-charts/ibm-open-liberty
 ```
+
+[system]#*{win}*#
+
+[role=command]
+```
+helm install --name ping-app ^
+    --set image.repository=registry.ng.bluemix.net/[your-namespace]/ping ^
+    --set image.tag=1.0-SNAPSHOT ^
+    --set service.port=9080 ^
+    --set service.targetPort=9080 ^
+    --set ssl.enabled=false ^
+    ibm-charts/ibm-open-liberty
+```
+
+****
+
 
 After running `helm install` output will be displayed providing instructions on how to access your deployed microservices. Ignore these instructions for now, you will learn how to access your microservices in the next section.
 
@@ -420,11 +458,25 @@ deployment of your chart. The following table gives an overview for each of the 
 
 === Finding the microservice's IP address and ports
 
-Get the public IP address of the cluster.
+First, find the current context of your cluster.
 
 [role=command]
 ```
-ibmcloud ks workers $(kubectl config current-context)
+kubectl config current-context
+```
+
+Take note of the context shown in the command's output.
+
+[source, role="no_copy"]
+----
+guide-cluster
+----
+
+Then, substitute the context into the following command to get the public IP address of your cluster.
+
+[role=command]
+```
+ibmcloud ks workers [current-context]
 ```
 
 Take note of the `Public IP` in the command's output.
@@ -626,6 +678,13 @@ helm delete --purge name-app
 helm delete --purge ping-app
 ```
 
+Uninstall Tiller from your cluster by running the following Helm command.
+
+[role=command]
+```
+helm reset
+```
+
 Logout of your Docker registry.
 
 [role=command]
@@ -652,15 +711,15 @@ ibmcloud logout
 
 Some situations may require you to manage your own infrastructure, such as if you want to deploy on-premises. If this describes your needs, then private clouds may be a more suitable solution for you.
 
-https://www.ibm.com/cloud/private[IBM Cloud Private] (ICP) is a {kube} platform. A private cloud may be a more attractive option to those who must run their services running on infrastructure controlled by them. While the operations team will still need to maintain this infrastructure, a private cloud still provides benefit to developers so they don't need to think about infrastructure. {kube} acts as an abstraction of the infrastructure so the developers can request what they need and it is the responsibility of the infrastructure's maintainers to provide the necessary resources.
+https://www.ibm.com/cloud/private[IBM Cloud Private^] (ICP) is a {kube} platform. A private cloud may be a more attractive option to those who must run their services running on infrastructure controlled by them. While the operations team will still need to maintain this infrastructure, a private cloud still provides benefit to developers so they don't need to think about infrastructure. {kube} acts as an abstraction of the infrastructure so the developers can request what they need and it is the responsibility of the infrastructure's maintainers to provide the necessary resources.
 
 Deploying microservices to ICP is a similar process as deploying to IKS. The main differences you will notice are in the setup process and how you tag your Docker images.
 
-To obtain an ICP instance see the https://www.ibm.com/cloud/private[IBM Cloud Private] website. To set up your local environment, from the ICP Dashboard navigate to the `Command Line Tools > Cloud Private CLI` page from the menu and follow the instructions to set up each CLI tool. Unlike IKS, you will not need to run `helm init` or deploy the cluster role binding and service account to your cluster because ICP has Helm's Tiller setup for you out of the box. To connect your local command line tools to the ICP instance, use https://www.ibm.com/support/knowledgecenter/en/SSBS6K_3.1.0/manage_cluster/cli_commands.html#login[cloudctl login].
+To obtain an ICP instance see the https://www.ibm.com/cloud/private[IBM Cloud Private^] website. To set up your local environment, from the ICP Dashboard navigate to the `Command Line Tools > Cloud Private CLI` page from the menu and follow the instructions to set up each CLI tool. Unlike IKS, you will not need to run `helm init` or deploy the cluster role binding and service account to your cluster because ICP has Helm's Tiller setup for you out of the box. To connect your local command line tools to the ICP instance, use https://www.ibm.com/support/knowledgecenter/en/SSBS6K_3.1.0/manage_cluster/cli_commands.html#login[cloudctl login^].
 
 When you tag a Docker image, you must tag the image with the registry as a prefix to your image name. This prefix is how Docker knows which registry to push your images to. For example, assume your ICP instance's Docker registry is `mycluster.icp:8500`. To tag your image appropriately, you must prefix the image name with the registry and namespace. Let's say you want to push your image to a repository in the default namespace, then you would tag your `name` microservice's image `mycluster.icp:8500/default/name`. This tag specifies `mycluster.icp:8500` as the Docker registry to push to and it specifies `default` as the namespace your image's repository will reside in.
 
-You can learn more about deploying microservices to ICP by following an https://www.ibm.com/cloud/garage/demo/try-private-cloud-install-an-app[interactive guided demo].
+You can learn more about deploying microservices to ICP by following an https://www.ibm.com/cloud/garage/demo/try-private-cloud-install-an-app[interactive guided demo^].
 
 // =================================================================================================
 // finish


### PR DESCRIPTION
Open links in new tab
Describe Helm in "What you'll learn"
Minor change to pre-reqs section
Change instruction to use powershell to command prompt
Split helm install commands to be platform specific
Remove usage of command substitution for compatibility with Windows
Add instruction to uninstall Tiller in teardown