### PR TITLE
Remove Helm chart dependency

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/prod
 :source-highlighter: prettify
 :page-seo-title: Deploying Java microservices to IBM Cloud Kubernetes Service
-:page-seo-description: A getting started tutorial with examples on how to deploy Java microservices to IBM Cloud Kubernetes Service using IBM Cloud Container Registry and Helm.
+:page-seo-description: A getting started tutorial with examples on how to deploy Java microservices to IBM Cloud Kubernetes Service using IBM Cloud Container Registry.
 :guide-author: Open Liberty
 = Deploying microservices to IBM Cloud Kubernetes Service
 
@@ -52,8 +52,6 @@ The IBM Cloud Kubernetes Service is part of IBM’s public cloud offerings. It p
 
 The two microservices you will deploy are called `system` and `inventory`. The `system` microservice returns the JVM system properties of the running container. It also returns the pod’s name in the HTTP header, making replicas easy to distinguish from each other. The `inventory` microservice adds the properties from the `system` microservice to the inventory. This configuration demonstrates how to establish communication between pods inside a cluster.
 
-You will use Helm to deploy these microservices to IBM Cloud by using Open Liberty Helm charts. Helm is a package manager for {kube}. It uses templates to generate {kube} YAML files and then deploys and manages them as releases in your cluster. 
-
 
 // =================================================================================================
 // Prerequisites
@@ -66,8 +64,6 @@ Before you begin, the following additional tools need to be installed:
 * *Docker:* You need a containerization software for building containers. {kube} supports various container types, but you will use Docker in this guide. For installation instructions, refer to the official https://docs.docker.com/install/[Docker^] documentation.
 
 * *kubectl:* You need the {kube} command-line tool `kubectl` to interact with your {kube} cluster. See the official https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl[Install and Set Up kubectl^] documentation for information about downloading and setting up `kubectl` on your platform.
-
-* *Helm:* You will use the Helm Command Line Interface (CLI) to manage releases in your {kube} cluster. Download https://github.com/helm/helm/releases[Helm^] and see the official https://helm.sh/docs/intro/install/[Installing Helm^] documentation for information about setting up `helm` on your platform.
 
 * *IBM Cloud CLI:* You will use the IBM Cloud CLI to interact with IBM Cloud. To install the IBM Cloud CLI for your platform, run one of the following commands:
 
@@ -328,120 +324,52 @@ docker push us.icr.io/[your-namespace]/inventory:1.0-SNAPSHOT
 // Deploying the microservices
 // =================================================================================================
 
+
+// =================================================================================================
+// Deploying the microservices
+// =================================================================================================
+
 === Deploying the microservices
 
-https://helm.sh/[Helm^] is a package manager for {kube}. It allows you to create a package called a chart. You can install a chart on your cluster as a release and then manage the release using Helm.
+Now that your container images are built, deploy them using a Kubernetes resource definition.
 
-// Add repo
-Add the `ibm-charts` repository to your local list of Helm repositories. Adding the repository allows you to use the `ibm-open-liberty` chart.
+A Kubernetes resource definition is a yaml file that contains a description of all your deployments, services, or any other resources that you want to deploy. All resources can also be deleted from the cluster by using the same yaml file that you used to deploy them. The `kubernetes.yaml` resource definition file is provided for you. If you are interested in learning more about the Kubernetes resource definition, check out the https://openliberty.io/guides/kubernetes-intro.html[Deploying microservices to Kubernetes^] guide.
 
-[role=command]
+[role="code_command hotspot", subs="quotes"]
+----
+#Update the `kubernetes.yaml` file in the `start` directory.#
+`kubernetes.yaml`
+----
+
+kubernetes.yaml
+[source, yaml, linenums, role='code_column']
+----
+include::finish/kubernetes.yaml[]
+----
+[role="edit_command_text"]
+The [hotspot=18 hotspot=39]`image` is the name and tag of the container image that you want to use for the container. Update the system [hotspot=18]`image` and the inventory [hotspot=39]`image` fields to point to your `system` and `inventory` repository URIs.
+
+
+Run the following commands to deploy the resources as defined in kubernetes.yaml:
+[role='command']
 ```
-helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+kubectl apply -f kubernetes.yaml
 ```
 
-// Deploy to IKS
-Use Helm to deploy the `system` microservice. Remember to replace `us.icr.io` to your registry and `[your-namespace]` with the namespace you created earlier in the guide.
-
-include::{common-includes}/os-tabs.adoc[]
-
-[.tab_content.windows_section]
---
-[role=command]
-```
-helm install system-app ^
-    --set image.repository=us.icr.io/[your-namespace]/system ^
-    --set image.tag=1.0-SNAPSHOT ^
-    --set image.pullSecret=all-icr-io ^
-    --set service.name=system-service ^
-    --set service.port=9080 ^
-    --set service.targetPort=9080 ^
-    --set ssl.enabled=false ^
-    ibm-charts/ibm-open-liberty
-```
---
-
-[.tab_content.mac_section.linux_section]
-
---
-[role=command]
-```
-helm install system-app \
-    --set image.repository=us.icr.io/[your-namespace]/system \
-    --set image.tag=1.0-SNAPSHOT \
-    --set image.pullSecret=all-icr-io \
-    --set service.name=system-service \
-    --set service.port=9080 \
-    --set service.targetPort=9080 \
-    --set ssl.enabled=false \
-    ibm-charts/ibm-open-liberty
-```
---
-
-Use Helm to deploy the `inventory` microservice. Remember to replace `us.icr.io` to your registry and `[your-namespace]` with the namespace you created earlier in the guide.
-
-include::{common-includes}/os-tabs.adoc[]
-
-[.tab_content.windows_section]
---
-[role=command]
-```
-helm install inventory-app ^
-    --set image.repository=us.icr.io/[your-namespace]/inventory ^
-    --set image.tag=1.0-SNAPSHOT ^
-    --set image.pullSecret=all-icr-io ^
-    --set service.name=inventory-service ^
-    --set service.port=9080 ^
-    --set service.targetPort=9080 ^
-    --set ssl.enabled=false ^
-    ibm-charts/ibm-open-liberty
-```
---
-
-[.tab_content.mac_section.linux_section]
---
-[role=command]
-```
-helm install inventory-app \
-    --set image.repository=us.icr.io/[your-namespace]/inventory \
-    --set image.tag=1.0-SNAPSHOT \
-    --set image.pullSecret=all-icr-io \
-    --set service.name=inventory-service \
-    --set service.port=9080 \
-    --set service.targetPort=9080 \
-    --set ssl.enabled=false \
-    ibm-charts/ibm-open-liberty
-```
---
-
-After you run `helm install`, an output is displayed providing instructions on how to access your deployed microservices. Ignore these instructions for now, you will learn how to access your microservices in the next section.
-
-The string literal after `helm install` specifies the release name, which must be unique. This is the name that Helm uses to identify this specific deployment of your chart. The following table gives an overview for each of the parameters specified using `--set`.
-
-|===
-| *Parameter* | *Description*
-| `image.repository` | The name of your Docker image including registry/repository prefix
-| `image.tag` | The tag for your Docker image
-| `image.pullSecret` | The image pull secret, because the container registry is private
-| `service.name` | The name of the service
-| `service.port` | The port exposed by the service
-| `service.targetPort` | The port exposed by the pod
-| `ssl.enabled` | Specify if SSL is enabled
-|===
-
-Use the following command to find the status of the pods running the `system` and `inventory` microservices. Wait until the status of both microservices is `Running`.
-
-[role=command]
+When the apps are deployed, run the following command to check the status of your pods:
+[role='command']
 ```
 kubectl get pods
 ```
 
+If all the pods are healthy and running, you see an output similar to the following:
 [source, role="no_copy"]
 ----
-NAME                                        READY     STATUS    RESTARTS   AGE
-inventory-app-ibm-open-l-5c586b9cfc-h5zmg   1/1       Running   0          23s
-system-app-ibm-open-libe-84976bccfb-r22lj   1/1       Running   0          23s
+NAME                                    READY     STATUS    RESTARTS   AGE
+system-deployment-6bd97d9bf6-4ccds      1/1       Running   0          15s
+inventory-deployment-645767664f-nbtd9   1/1       Running   0          15s
 ----
+
 
 === Finding the microservice's IP address and ports
 
@@ -543,7 +471,7 @@ Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
 
 == Deploying a new version of system microservice
 
-Optionally, you might want to make changes to your microservice and redeploy the updated version. In this section, you will bump the version of the `system` microservice to `2.0-SNAPSHOT` and redeploy the new version of the microservice. You can redeploy a microservice by using Helm to upgrade the release.
+Optionally, you might want to make changes to your microservice and redeploy the updated version. In this section, you will bump the version of the `system` microservice to `2.0-SNAPSHOT` and redeploy the new version of the microservice. 
 
 Use Maven to repackage your microservice:
 [role=command]
@@ -575,41 +503,12 @@ Push your image to the registry.
 docker push us.icr.io/[your-namespace]/system:2.0-SNAPSHOT
 ```
 
-Use Helm to redeploy the `system` microservice.
+Update the `system-deployment` deployment to use the new container image that you just pushed to the registry:
 
-include::{common-includes}/os-tabs.adoc[]
-
-[.tab_content.windows_section]
---
 [role=command]
 ```
-helm upgrade ^
-    --set image.repository=us.icr.io/[your-namespace]/system ^
-    --set image.tag=2.0-SNAPSHOT ^
-    --set image.pullSecret=all-icr-io ^
-    --set service.name=system-service ^
-    --set service.port=9080 ^
-    --set service.targetPort=9080 ^
-    --set ssl.enabled=false ^
-    system-app ibm-charts/ibm-open-liberty
+kubectl set image deployment/system-deployment system-container=us.icr.io/[your-namespace]/system:2.0-SNAPSHOT
 ```
---
-
-[.tab_content.mac_section.linux_section]
---
-[role=command]
-```
-helm upgrade \
-    --set image.repository=us.icr.io/[your-namespace]/system \
-    --set image.tag=2.0-SNAPSHOT \
-    --set image.pullSecret=all-icr-io \
-    --set service.name=system-service \
-    --set service.port=9080 \
-    --set service.targetPort=9080 \
-    --set ssl.enabled=false \
-    system-app ibm-charts/ibm-open-liberty
-```
---
 
 Use the following command to find the name of the pod that is running the `system` microservice.
 
@@ -655,12 +554,10 @@ LAST SEEN   TYPE     REASON      OBJECT                                         
 
 == Tearing down the environment
 
-When you no longer need your deployed microservices, you can delete them with the following Helm commands:
-
-[role=command]
+When you no longer need your deployed microservices, you can delete all {kube} resources by running the `kubectl delete` command:
+[role='command']
 ```
-helm uninstall system-app
-helm uninstall inventory-app
+kubectl delete -f kubernetes.yaml
 ```
 
 Remove your images from your container registry. Remember to replace `us.icr.io` to your registry and `[your-namespace]` with the namespace you created earlier in the guide.
@@ -707,7 +604,7 @@ ibmcloud logout
 
 == Great work! You're done!
 
-You just deployed two microservices to IBM Cloud. You learned to use Helm to install your microservices on a {kube} cluster by using the Open Liberty helm chart.
+You just deployed two microservices to IBM Cloud. You also learned how to use the `kubectl` command to deploy your microservices on a {kube} cluster.
 
 // Multipane
 include::{common-includes}/attribution.adoc[subs="attributes"]

--- a/finish/kubernetes.yaml
+++ b/finish/kubernetes.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-deployment
+  labels:
+    app: system
+spec:
+  selector:
+    matchLabels:
+      app: system
+  template:
+    metadata:
+      labels:
+        app: system
+    spec:
+      containers:
+      - name: system-container
+        image: us.icr.io/[your-namespace]/system:1.0-SNAPSHOT
+        ports:
+        - containerPort: 9080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-deployment
+  labels:
+    app: inventory
+spec:
+  selector:
+    matchLabels:
+      app: inventory
+  template:
+    metadata:
+      labels:
+        app: inventory
+    spec:
+      containers:
+      - name: inventory-container
+        image: us.icr.io/[your-namespace]/inventory:1.0-SNAPSHOT
+        ports:
+        - containerPort: 9080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: system-service
+spec:
+  type: NodePort
+  selector:
+    app: system
+  ports:
+  - protocol: TCP
+    port: 9080
+    targetPort: 9080
+    nodePort: 31000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-service
+spec:
+  type: NodePort
+  selector:
+    app: inventory
+  ports:
+  - protocol: TCP
+    port: 9080
+    targetPort: 9080
+    nodePort: 32000

--- a/scripts/testApp.sh
+++ b/scripts/testApp.sh
@@ -34,8 +34,7 @@ mvn failsafe:verify
 kubectl logs "$(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep system)"
 kubectl logs "$(kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}' | grep inventory)"
 
-helm uninstall system-app
-helm uninstall inventory-app
+kubectl delete -f kubernetes.yaml
 
 ../scripts/stopMinikube.sh
 

--- a/scripts/testApp.sh
+++ b/scripts/testApp.sh
@@ -13,31 +13,11 @@ docker pull icr.io/appcafe/open-liberty:kernel-slim-java11-openj9-ubi
 docker build --no-cache -t system:1.0-SNAPSHOT system/.
 docker build --no-cache -t inventory:1.0-SNAPSHOT inventory/.
 
-sleep 20
+sed -i 's|us.icr.io/\[your-namespace\]/||g' kubernetes.yaml
 
-helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+kubectl apply -f kubernetes.yaml
 
-helm install system-app \
-    --set image.repository=system \
-    --set image.tag=1.0-SNAPSHOT \
-    --set service.name=system-service \
-    --set service.port=9080 \
-    --set service.targetPort=9080 \
-    --set ssl.enabled=false \
-    ibm-charts/ibm-open-liberty 
-
-sleep 60
-
-helm install inventory-app \
-    --set image.repository=inventory \
-    --set image.tag=1.0-SNAPSHOT \
-    --set service.name=inventory-service \
-    --set service.port=9080 \
-    --set service.targetPort=9080 \
-    --set ssl.enabled=false \
-    ibm-charts/ibm-open-liberty
-
-sleep 60
+sleep 120
 
 kubectl get pods
 


### PR DESCRIPTION
Switch to deploying Kubernetes manifest file directly (instead of the Open Liberty Helm chart) and be more consistent with Azure and AWS guides.

Issue: https://github.com/OpenLiberty/guides-common/issues/851