### PR TITLE
Merge staging to prod - fix os tabs not work (#213)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,8 +70,6 @@ Before you begin, the following additional tools need to be installed:
 
 * *IBM Cloud CLI:* You will use the IBM Cloud CLI to interact with IBM Cloud. To install the IBM Cloud CLI for your platform, run one of the following commands:
 
-+
-
 include::{common-includes}/os-tabs.adoc[]
 
 [.tab_content.windows_section]


### PR DESCRIPTION
os tabs in the Additional prerequisites section do not work